### PR TITLE
Fixing links to "Start a project"

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ title: Get Involved
 			<div class="col-lg-4">
 				<h1>Hack!</h1>
 				<p><a href="projects">Find a project &raquo;</a></p>
-				<p><a href="/guides/projectguide.html">Start a project &raquo;</a></p>
+				<p><a href="/resources/startaproject.html">Start a project &raquo;</a></p>
 			</div>
 			<div class="well col-lg-12">
 				All Code for DC events and activities, both online and offline, are governed by our <a href="/docs/codeofconduct.html">Code of Conduct</a>. Please take a few minutes to familiarize yourself with it.

--- a/projects/index.html
+++ b/projects/index.html
@@ -72,7 +72,7 @@ extra_js:
 					</div>
 				</div>
 			</form>
-            <div>The requirements for a Code for DC project can be found <a href="/resources/projectguide.html">here</a>.</div>
+            <div>The requirements for a Code for DC project can be found <a href="/resources/startaproject.html">here</a>.</div>
 		</div>
 		<hr class="col-lg-12">
 		<div class="col-lg-12">


### PR DESCRIPTION
#122 was closed but the commit didn't fix the broken links.  Took a stab that it needed to point to ```/resources/startaproject.html```.  Submitting pull request against master instead of directly to gh-pages because it seems like that's where site changes are first proposed.

May also close #115.