### PR TITLE
Replaced deprecated .error call with on("error", fn)

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -451,7 +451,7 @@ $(document).ready(function(){
 	$(window).trigger('resize');
 
 	// Hide CI reports that 404'd
-	$("img").error(function () {
+	$("img").on("error", function () {
 	    $(this).hide();
 	});
 


### PR DESCRIPTION
>As of jQuery 1.8, the .error() method is deprecated. Use .on( "error", handler ) to attach event handlers to the error event instead.
http://api.jquery.com/error/

This resulted in the spinner.stop() not getting hit :(